### PR TITLE
fix: check if the buttons are in the is_pressed state

### DIFF
--- a/bin/screenshot-monitor
+++ b/bin/screenshot-monitor
@@ -7,7 +7,7 @@ main() {
 
     while true; do
         echo "Waiting for $HOTKEY..."
-        "$PROGDIR/bin/minui-btntest-$PLATFORM" wait just_released all "$HOTKEY"
+        "$PROGDIR/bin/minui-btntest-$PLATFORM" wait is_pressed all "$HOTKEY"
         echo "Taking screenshot..."
         "$PROGDIR/bin/screenshot" &
     done


### PR DESCRIPTION
Without this, we can't check for button combinations on the Brick (not clear why without diving into the polling implementation tbh).